### PR TITLE
updates for phergie version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2014, Phergie Development Team
+Copyright (c) 2008-2015, Phergie Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The recommended method of installation is [through composer](http://getcomposer.
 ```JSON
 {
     "require": {
-        "phergie/phergie-irc-plugin-react-youtube": "dev-master"
+        "phergie/phergie-irc-plugin-react-youtube": "~2"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "require": {
         "phergie/phergie-irc-bot-react": "^2",
-        "phergie/phergie-irc-plugin-react-url": "^2",
+        "phergie/phergie-irc-plugin-react-url": "^3",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "phergie/phergie-irc-bot-react": "^1",
-        "phergie/phergie-irc-plugin-react-url": "^1",
+        "phergie/phergie-irc-bot-react": "^2",
+        "phergie/phergie-irc-plugin-react-url": "^2",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "db1fcc630fe1c510801debc906e2fcd2",
-    "content-hash": "62f7c79fcd54fa57e77800750a58293b",
+    "hash": "8d6170aee041aadf327dda0c5b365afa",
+    "content-hash": "68606d53e0bf7863109bfd45f8c60670",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -52,6 +52,58 @@
                 "event-emitter"
             ],
             "time": "2014-07-09 21:08:03"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "5.3.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "cb8d0f2e778af4c9f669684a934a5f910ef37696"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/cb8d0f2e778af4c9f669684a934a5f910ef37696",
+                "reference": "cb8d0f2e778af4c9f669684a934a5f910ef37696",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2015-12-29 21:28:28"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -112,17 +164,118 @@
             "time": "2015-11-03 01:34:55"
         },
         {
-            "name": "monolog/monolog",
-            "version": "1.17.2",
+            "name": "guzzlehttp/ringphp",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24"
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "9465032ac5d6beaa55f10923403e6e1c36018d9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
-                "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/9465032ac5d6beaa55f10923403e6e1c36018d9c",
+                "reference": "9465032ac5d6beaa55f10923403e6e1c36018d9c",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2015-05-21 17:23:02"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "d1f8a6c55f0f753cfd6f6755856473eb02cedb19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/d1f8a6c55f0f753cfd6f6755856473eb02cedb19",
+                "reference": "d1f8a6c55f0f753cfd6f6755856473eb02cedb19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2015-01-22 00:01:34"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "592af02d0c9a7f6c8a345958d8db5d068cf51147"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/592af02d0c9a7f6c8a345958d8db5d068cf51147",
+                "reference": "592af02d0c9a7f6c8a345958d8db5d068cf51147",
                 "shasum": ""
             },
             "require": {
@@ -151,6 +304,7 @@
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                 "ext-mongo": "Allow sending log messages to a MongoDB server",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "raven/raven": "Allow sending log messages to a Sentry server",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
@@ -160,7 +314,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -186,7 +340,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2015-10-14 12:51:02"
+            "time": "2015-12-18 18:24:15"
         },
         {
             "name": "nojimage/twitter-text-php",
@@ -253,35 +407,28 @@
         },
         {
             "name": "phergie/phergie-irc-bot-react",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phergie/phergie-irc-bot-react.git",
-                "reference": "ce94f71df696c7d379fcdd6c7b60aef73b8d8a78"
+                "reference": "d8587c51144dffe45dc925d87740a7f1e0ea23d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phergie/phergie-irc-bot-react/zipball/ce94f71df696c7d379fcdd6c7b60aef73b8d8a78",
-                "reference": "ce94f71df696c7d379fcdd6c7b60aef73b8d8a78",
+                "url": "https://api.github.com/repos/phergie/phergie-irc-bot-react/zipball/d8587c51144dffe45dc925d87740a7f1e0ea23d4",
+                "reference": "d8587c51144dffe45dc925d87740a7f1e0ea23d4",
                 "shasum": ""
             },
             "require": {
                 "evenement/evenement": "~2.0",
                 "monolog/monolog": "~1.6",
-                "phergie/phergie-irc-client-react": "~2.2",
+                "phergie/phergie-irc-client-react": "~3",
                 "phergie/phergie-irc-connection": "~2.0",
                 "phergie/phergie-irc-event": "~1.0",
-                "php": ">=5.4.2"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "codeclimate/php-test-reporter": "~0.1",
-                "phake/phake": "~2.0",
-                "phpunit/phpunit": "~4.6",
-                "satooshi/php-coveralls": "0.6.1",
-                "symfony/config": "~2.0",
-                "symfony/console": "~2.0",
-                "symfony/filesystem": "~2.0",
-                "symfony/stopwatch": "~2.0"
+                "phergie/phergie-irc-bot-react-development": "~1.0"
             },
             "bin": [
                 "bin/phergie"
@@ -302,20 +449,20 @@
                 "irc",
                 "react"
             ],
-            "time": "2015-07-16 17:22:01"
+            "time": "2015-12-21 21:17:58"
         },
         {
             "name": "phergie/phergie-irc-client-react",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phergie/phergie-irc-client-react.git",
-                "reference": "5d0cf542ca9391e515eddef3554815f80bda60ed"
+                "reference": "55efba19c7a48764d4b997d5e9d473e0f75db232"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phergie/phergie-irc-client-react/zipball/5d0cf542ca9391e515eddef3554815f80bda60ed",
-                "reference": "5d0cf542ca9391e515eddef3554815f80bda60ed",
+                "url": "https://api.github.com/repos/phergie/phergie-irc-client-react/zipball/55efba19c7a48764d4b997d5e9d473e0f75db232",
+                "reference": "55efba19c7a48764d4b997d5e9d473e0f75db232",
                 "shasum": ""
             },
             "require": {
@@ -323,7 +470,7 @@
                 "phergie/phergie-irc-connection": "~2.0",
                 "phergie/phergie-irc-generator": "~1.5",
                 "phergie/phergie-irc-parser": "~2.0",
-                "php": ">=5.4.2",
+                "php": ">=5.5",
                 "psr/log": "~1.0",
                 "react/dns": "~0.4.0",
                 "react/event-loop": "~0.4.0",
@@ -331,15 +478,11 @@
                 "react/socket-client": "~0.4.2",
                 "react/stream": "~0.4.2"
             },
+            "conflict": {
+                "phergie/phergie-irc-plugin-react-pong": "*"
+            },
             "require-dev": {
-                "codeclimate/php-test-reporter": "~0.1",
-                "phake/phake": "~2.1",
-                "phpunit/phpunit": "~4.6",
-                "satooshi/php-coveralls": "0.6.1",
-                "symfony/config": "~2.0",
-                "symfony/console": "~2.0",
-                "symfony/filesystem": "~2.0",
-                "symfony/stopwatch": "~2.0"
+                "phergie/phergie-irc-bot-react-development": "~1.0.0"
             },
             "type": "library",
             "autoload": {
@@ -357,7 +500,7 @@
                 "irc",
                 "react"
             ],
-            "time": "2015-07-16 17:05:02"
+            "time": "2015-12-14 23:56:41"
         },
         {
             "name": "phergie/phergie-irc-connection",
@@ -476,23 +619,23 @@
         },
         {
             "name": "phergie/phergie-irc-parser",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phergie/phergie-irc-parser.git",
-                "reference": "29fd291f93b0881c5fc47ae6e5e41b96e7824805"
+                "reference": "cec7ec29ea9bbad5f3d1c0e0271279b3d58fe6ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phergie/phergie-irc-parser/zipball/29fd291f93b0881c5fc47ae6e5e41b96e7824805",
-                "reference": "29fd291f93b0881c5fc47ae6e5e41b96e7824805",
+                "url": "https://api.github.com/repos/phergie/phergie-irc-parser/zipball/cec7ec29ea9bbad5f3d1c0e0271279b3d58fe6ce",
+                "reference": "cec7ec29ea9bbad5f3d1c0e0271279b3d58fe6ce",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.2"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.6"
+                "phergie/phergie-irc-bot-react-development": "~1.0.0"
             },
             "type": "library",
             "autoload": {
@@ -509,53 +652,162 @@
                 "irc",
                 "parser"
             ],
-            "time": "2015-07-16 16:26:41"
+            "time": "2015-11-12 15:21:51"
         },
         {
-            "name": "phergie/phergie-irc-plugin-react-url",
-            "version": "1.0.1",
+            "name": "phergie/phergie-irc-plugin-dns",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phergie/phergie-irc-plugin-react-url.git",
-                "reference": "a9124f42fd23b862d0a9a6030cd8497ae176be0b"
+                "url": "https://github.com/phergie/plugin-dns.git",
+                "reference": "e24af66296819c2c02804a1cbe0fbcef63cd9e15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phergie/phergie-irc-plugin-react-url/zipball/a9124f42fd23b862d0a9a6030cd8497ae176be0b",
-                "reference": "a9124f42fd23b862d0a9a6030cd8497ae176be0b",
+                "url": "https://api.github.com/repos/phergie/plugin-dns/zipball/e24af66296819c2c02804a1cbe0fbcef63cd9e15",
+                "reference": "e24af66296819c2c02804a1cbe0fbcef63cd9e15",
                 "shasum": ""
             },
             "require": {
-                "nojimage/twitter-text-php": "1.1.1",
-                "phergie/phergie-irc-bot-react": "~1.0",
-                "php": ">=5.4.0",
-                "react/promise": "~1.0|~2.0",
-                "wyrihaximus/phergie-http": "~1.0|~2.0"
+                "phergie/phergie-irc-bot-react": "^2.0",
+                "php": ">=5.5",
+                "react/dns": "^0.4.1"
             },
             "require-dev": {
-                "phake/phake": "~1.0",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.0",
-                "vectorface/dunit": "~2.0"
+                "phergie/phergie-irc-bot-react-development": "^1.0.2|^1.1",
+                "phergie/phergie-irc-plugin-react-command": "^2"
+            },
+            "suggest": {
+                "phergie/phergie-irc-plugin-react-command": "Required if you want to make use of the command support"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "WyriHaximus\\Phergie\\Plugin\\Url\\": "src"
+                    "Phergie\\Plugin\\Dns\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "Phergie plugin for Display URL information about links",
+            "authors": [
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                }
+            ],
+            "description": "Phergie plugin for Looking up IP's by hostnames",
+            "keywords": [
+                "bot",
+                "irc",
+                "phergie",
+                "phergieplugin",
+                "plugin",
+                "react"
+            ],
+            "time": "2015-12-28 23:49:13"
+        },
+        {
+            "name": "phergie/phergie-irc-plugin-http",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phergie/plugin-http.git",
+                "reference": "6f44190806e0817c0fd1dfb06bf221903dddf7cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phergie/plugin-http/zipball/6f44190806e0817c0fd1dfb06bf221903dddf7cc",
+                "reference": "6f44190806e0817c0fd1dfb06bf221903dddf7cc",
+                "shasum": ""
+            },
+            "require": {
+                "phergie/phergie-irc-bot-react": "~2.0",
+                "phergie/phergie-irc-plugin-dns": "^4.0",
+                "php": "^5.5||^7.0",
+                "wyrihaximus/react-guzzle-ring": "^1.0"
+            },
+            "require-dev": {
+                "phergie/phergie-irc-bot-react-development": "^1.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phergie\\Plugin\\Http\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                }
+            ],
+            "description": "Phergie plugin for Provide HTTP functionality to other plugins",
+            "keywords": [
+                "bot",
+                "irc",
+                "phergie",
+                "phergieplugin",
+                "plugin",
+                "react"
+            ],
+            "time": "2015-12-29 12:41:31"
+        },
+        {
+            "name": "phergie/phergie-irc-plugin-react-url",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phergie/phergie-irc-plugin-react-url.git",
+                "reference": "86626c6e771253252fae157483174f3b1718a907"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phergie/phergie-irc-plugin-react-url/zipball/86626c6e771253252fae157483174f3b1718a907",
+                "reference": "86626c6e771253252fae157483174f3b1718a907",
+                "shasum": ""
+            },
+            "require": {
+                "nojimage/twitter-text-php": "1.1.1",
+                "phergie/phergie-irc-bot-react": "~2",
+                "phergie/phergie-irc-plugin-http": "^4",
+                "php": "^5.5|^7.0",
+                "react/promise": "~1.0|~2.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "~0.1",
+                "phake/phake": "dev-VerifierResultConstraint-issue",
+                "phpunit/phpunit": "^4.6.0",
+                "satooshi/php-coveralls": "0.6.1",
+                "squizlabs/php_codesniffer": "^1.5.3",
+                "symfony/config": "~2.0",
+                "symfony/console": "~2.0",
+                "symfony/filesystem": "~2.0",
+                "symfony/stopwatch": "~2.0",
+                "vectorface/dunit": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phergie\\Irc\\Plugin\\React\\Url\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Phergie plugin for displaying information about URLs",
             "keywords": [
                 "bot",
                 "irc",
                 "plugin",
                 "react"
             ],
-            "time": "2015-04-24 15:42:51"
+            "time": "2015-12-31 14:42:09"
         },
         {
             "name": "psr/http-message",
@@ -697,19 +949,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/dns.git",
-                "reference": "3fa027f1fe57e146203538c41db5b3e6c296b67a"
+                "reference": "ded1ec36faf703eb55b8d1c044c50a22569e1643"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/dns/zipball/3fa027f1fe57e146203538c41db5b3e6c296b67a",
-                "reference": "3fa027f1fe57e146203538c41db5b3e6c296b67a",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/ded1ec36faf703eb55b8d1c044c50a22569e1643",
+                "reference": "ded1ec36faf703eb55b8d1c044c50a22569e1643",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0",
-                "react/cache": "0.4.*",
-                "react/promise": "~2.0",
-                "react/socket": "0.4.*"
+                "php": ">=5.3.0",
+                "react/cache": "~0.4.0|~0.3.0",
+                "react/promise": "~2.0|~1.1",
+                "react/socket": "~0.4.0|~0.3.0"
             },
             "type": "library",
             "extra": {
@@ -731,7 +983,7 @@
                 "dns",
                 "dns-resolver"
             ],
-            "time": "2015-09-06 18:06:51"
+            "time": "2015-11-21 13:31:21"
         },
         {
             "name": "react/event-loop",
@@ -912,12 +1164,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/socket-client.git",
-                "reference": "5e3c4c60b14204660ffedc5e1d6813c708b2ce2c"
+                "reference": "0460210df73dc2867b7b3c65a75575d0bf5eee86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/socket-client/zipball/5e3c4c60b14204660ffedc5e1d6813c708b2ce2c",
-                "reference": "5e3c4c60b14204660ffedc5e1d6813c708b2ce2c",
+                "url": "https://api.github.com/repos/reactphp/socket-client/zipball/0460210df73dc2867b7b3c65a75575d0bf5eee86",
+                "reference": "0460210df73dc2867b7b3c65a75575d0bf5eee86",
                 "shasum": ""
             },
             "require": {
@@ -946,7 +1198,7 @@
             "keywords": [
                 "Socket"
             ],
-            "time": "2015-09-24 13:51:48"
+            "time": "2015-11-21 12:03:35"
         },
         {
             "name": "react/stream",
@@ -997,99 +1249,99 @@
             "time": "2015-10-07 18:32:58"
         },
         {
-            "name": "wyrihaximus/phergie-dns",
-            "version": "2.1.1",
+            "name": "wyrihaximus/react-guzzle-http-client",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WyriHaximus/PhergieDns.git",
-                "reference": "9afa9041238711ab4320d54f0415900e388c9ea4"
+                "url": "https://github.com/WyriHaximus/react-guzzle-http-client.git",
+                "reference": "2a18aa3a6cb6d6c565827d63e8c344a7a8755741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WyriHaximus/PhergieDns/zipball/9afa9041238711ab4320d54f0415900e388c9ea4",
-                "reference": "9afa9041238711ab4320d54f0415900e388c9ea4",
+                "url": "https://api.github.com/repos/WyriHaximus/react-guzzle-http-client/zipball/2a18aa3a6cb6d6c565827d63e8c344a7a8755741",
+                "reference": "2a18aa3a6cb6d6c565827d63e8c344a7a8755741",
                 "shasum": ""
             },
             "require": {
-                "phergie/phergie-irc-bot-react": "~1.0",
-                "php": ">=5.4.0",
-                "react/dns": "0.4.*"
+                "guzzlehttp/psr7": "^1.0",
+                "php": "^5.4|^7.0",
+                "psr/http-message": "^1.0",
+                "react/dns": "^0.4.1",
+                "react/http-client": "^0.4"
             },
             "require-dev": {
-                "phake/phake": "~1.0",
-                "phergie/phergie-irc-plugin-react-command": "~1.0",
-                "phpunit/phpunit": "~4.0",
-                "vectorface/dunit": "dev-master"
-            },
-            "suggest": {
-                "phergie/phergie-irc-plugin-react-command": "Required if you want to make use of the command support"
+                "phake/phake": "~1.0.6",
+                "phpunit/phpunit": "^4.0|^5.0",
+                "squizlabs/php_codesniffer": "~1.5.0",
+                "vectorface/dunit": "~2"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "WyriHaximus\\Phergie\\Plugin\\Dns\\": "src"
+                    "WyriHaximus\\React\\Guzzle\\HttpClient\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "Phergie plugin for Looking up IP's by hostnames",
-            "keywords": [
-                "bot",
-                "irc",
-                "phergie",
-                "phergieplugin",
-                "plugin",
-                "react"
+            "authors": [
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com",
+                    "homepage": "http://wyrihaximus.net/"
+                }
             ],
-            "time": "2015-09-13 07:35:13"
+            "description": "Asyncronous GuzzleRing adapter powered by react/http-client",
+            "time": "2015-11-03 17:37:13"
         },
         {
-            "name": "wyrihaximus/phergie-http",
-            "version": "2.1.1",
+            "name": "wyrihaximus/react-guzzle-ring",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WyriHaximus/PhergieHttp.git",
-                "reference": "26a89d7c927e3518520de5ad1766efb7a3edfbc7"
+                "url": "https://github.com/WyriHaximus/ReactGuzzleRing.git",
+                "reference": "2967e48438f6b4142e571e845e2ed8176aaa7ad0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WyriHaximus/PhergieHttp/zipball/26a89d7c927e3518520de5ad1766efb7a3edfbc7",
-                "reference": "26a89d7c927e3518520de5ad1766efb7a3edfbc7",
+                "url": "https://api.github.com/repos/WyriHaximus/ReactGuzzleRing/zipball/2967e48438f6b4142e571e845e2ed8176aaa7ad0",
+                "reference": "2967e48438f6b4142e571e845e2ed8176aaa7ad0",
                 "shasum": ""
             },
             "require": {
-                "phergie/phergie-irc-bot-react": "~1.0",
-                "php": ">=5.4.0",
-                "react/http-client": "0.4.*",
-                "wyrihaximus/phergie-dns": "~2.1"
+                "guzzlehttp/guzzle": "~5.0",
+                "guzzlehttp/psr7": "^1.1",
+                "guzzlehttp/ringphp": "~1.0",
+                "psr/http-message": "^1.0",
+                "react/dns": "^0.4.1",
+                "wyrihaximus/react-guzzle-http-client": "^3.0.0"
             },
             "require-dev": {
-                "phake/phake": "~1.0",
+                "phake/phake": "~1.0.6",
                 "phpunit/phpunit": "~4.0",
-                "vectorface/dunit": "dev-master"
+                "squizlabs/php_codesniffer": "~1.5.0",
+                "vectorface/dunit": "~2.0"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "WyriHaximus\\Phergie\\Plugin\\Http\\": "src"
+                    "WyriHaximus\\React\\RingPHP\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "Phergie plugin for Provide HTTP functionality to other plugins",
-            "keywords": [
-                "bot",
-                "irc",
-                "phergie",
-                "phergieplugin",
-                "plugin",
-                "react"
+            "authors": [
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com",
+                    "homepage": "http://wyrihaximus.net/"
+                }
             ],
-            "time": "2015-02-20 09:26:00"
+            "description": "Asyncronous GuzzleRing adapter powered by react/http-client",
+            "time": "2015-08-10 20:29:53"
         }
     ],
     "packages-dev": [
@@ -1149,16 +1401,16 @@
         },
         {
             "name": "phake/phake",
-            "version": "2.1.x-dev",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlively/Phake.git",
-                "reference": "199ba1d3c79a7d6c98fe8fc368b674475f010a4f"
+                "reference": "9c3c287ef3f23d5ca438917ab1a4f8c47b654b4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlively/Phake/zipball/199ba1d3c79a7d6c98fe8fc368b674475f010a4f",
-                "reference": "199ba1d3c79a7d6c98fe8fc368b674475f010a4f",
+                "url": "https://api.github.com/repos/mlively/Phake/zipball/9c3c287ef3f23d5ca438917ab1a4f8c47b654b4b",
+                "reference": "9c3c287ef3f23d5ca438917ab1a4f8c47b654b4b",
                 "shasum": ""
             },
             "require": {
@@ -1166,6 +1418,7 @@
                 "sebastian/comparator": "~1.1"
             },
             "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
                 "doctrine/common": "2.3.*",
                 "ext-soap": "*",
                 "hamcrest/hamcrest-php": "1.1.*",
@@ -1176,6 +1429,11 @@
                 "hamcrest/hamcrest-php": "Use Hamcrest matchers."
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.0-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Phake": "src/"
@@ -1197,7 +1455,7 @@
                 "mock",
                 "testing"
             ],
-            "time": "2015-05-18 00:03:35"
+            "time": "2015-11-30 17:02:04"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1254,18 +1512,20 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4f9b1eaf0a7da77c362f8d91cbc68ab1f4718d62"
+                "reference": "e55e3e32a870bd4f05425fa4f717b52bd40e5659"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4f9b1eaf0a7da77c362f8d91cbc68ab1f4718d62",
-                "reference": "4f9b1eaf0a7da77c362f8d91cbc68ab1f4718d62",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e55e3e32a870bd4f05425fa4f717b52bd40e5659",
+                "reference": "e55e3e32a870bd4f05425fa4f717b52bd40e5659",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
+                "sebastian/comparator": "~1.1",
+                "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "~2.0"
@@ -1306,7 +1566,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-09-22 14:49:23"
+            "time": "2015-12-28 13:26:33"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1554,12 +1814,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6f9251d0910483fcbe22ee7a47ed604e43070770"
+                "reference": "ea76b17bced0500a28098626b84eda12dbcf119c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6f9251d0910483fcbe22ee7a47ed604e43070770",
-                "reference": "6f9251d0910483fcbe22ee7a47ed604e43070770",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea76b17bced0500a28098626b84eda12dbcf119c",
+                "reference": "ea76b17bced0500a28098626b84eda12dbcf119c",
                 "shasum": ""
             },
             "require": {
@@ -1618,7 +1878,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-11-11 12:23:02"
+            "time": "2015-12-12 07:45:58"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1746,24 +2006,24 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "6899b3e33bfbd386d88b5eea5f65f563e8793051"
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/6899b3e33bfbd386d88b5eea5f65f563e8793051",
-                "reference": "6899b3e33bfbd386d88b5eea5f65f563e8793051",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1786,11 +2046,11 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2015-06-22 14:15:55"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
@@ -1798,12 +2058,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+                "reference": "6e7133793a8e5a5714a551a8324337374be209df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e7133793a8e5a5714a551a8324337374be209df",
+                "reference": "6e7133793a8e5a5714a551a8324337374be209df",
                 "shasum": ""
             },
             "require": {
@@ -1840,7 +2100,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-08-03 06:14:51"
+            "time": "2015-12-02 08:37:27"
         },
         {
             "name": "sebastian/exporter",
@@ -1966,12 +2226,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -2011,7 +2271,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "sebastian/version",
@@ -2054,12 +2314,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "5ff00ea2999343d42398fcb793bbfc64c92235ff"
+                "reference": "cee3fdda8184add20a13eb666295dfd72e8031bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/5ff00ea2999343d42398fcb793bbfc64c92235ff",
-                "reference": "5ff00ea2999343d42398fcb793bbfc64c92235ff",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/cee3fdda8184add20a13eb666295dfd72e8031bd",
+                "reference": "cee3fdda8184add20a13eb666295dfd72e8031bd",
                 "shasum": ""
             },
             "require": {
@@ -2095,7 +2355,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-05 09:04:44"
+            "time": "2015-12-28 13:12:56"
         }
     ],
     "aliases": [],

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,7 +13,7 @@ namespace Phergie\Irc\Plugin\React\YouTube;
 use Phergie\Irc\Bot\React\AbstractPlugin;
 use Phergie\Irc\Bot\React\EventQueueInterface as Queue;
 use Phergie\Irc\Event\EventInterface as Event;
-use WyriHaximus\Phergie\Plugin\Http\Request as HttpRequest;
+use Phergie\Plugin\Http\Request as HttpRequest;
 
 /**
  * Plugin class.

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -170,7 +170,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $params);
         $this->assertCount(1, $params);
         $request = reset($params);
-        $this->assertInstanceOf('\WyriHaximus\Phergie\Plugin\Http\Request', $request);
+        $this->assertInstanceOf('\Phergie\Plugin\Http\Request', $request);
         $this->assertSame($this->requestUrl, $request->getUrl());
 
         $config = $request->getConfig();


### PR DESCRIPTION
Similar to https://github.com/phergie/phergie-irc-plugin-react-url/pull/10 this depends on [phergie/phergie-irc-plugin-http](https://github.com/phergie/plugin-http/pull/2) also being upgraded to version 2. Will need to merge that PR and update composer here as well.